### PR TITLE
Implementing sim-crash and sim-recover endpoints

### DIFF
--- a/src/Node.py
+++ b/src/Node.py
@@ -15,7 +15,7 @@ def hash_value(value):
 class Node:
     
     # initializing a node
-    def __init__(self, address):
+    def __init__(self, address, r = 3):
         self.node_id = hash_value(address)
         self.address = address
         self.successor = self.address
@@ -23,6 +23,7 @@ class Node:
         self.data_store = {}
         self.finger_table = []
         self.crashed = False  # New flag to simulate a crash
+        self.successor_list = [self.address] * r
 
         print(f"Initializing node with address {self.address} and ID hash {self.node_id}", flush=True)
 
@@ -141,7 +142,7 @@ class Node:
         """Periodically checks the successor's predecessor and updates if needed."""
         try:
             # Attempt to get successor's predecessor
-            response = requests.get(f"http://{self.successor}/predecessor", timeout=5)  # Timeout to detect failure
+            response = requests.get(f"http://{self.successor}/predecessor", timeout=5)
             response.raise_for_status()
             successor_predecessor = response.json()['predecessor']
 
@@ -149,53 +150,62 @@ class Node:
             if successor_predecessor and hash_value(successor_predecessor) > hash_value(self.address) and hash_value(successor_predecessor) < hash_value(self.successor):
                 self.successor = successor_predecessor
 
+            # Update the successor list with the current successor's successor list
+            response = requests.get(f"http://{self.successor}/successor-list", timeout=5)
+            response.raise_for_status()
+            successor_successor_list = response.json()['successor_list']
+            self.successor_list = [self.successor] + successor_successor_list[:-1]  # Update our successor list
+
             # Notify the successor about this node
             response = requests.post(f"http://{self.successor}/update-predecessor", json={'predecessor': self.address}, timeout=5)
             response.raise_for_status()
 
+            self.update_finger_table()
+
             print(f"Stabilization complete for node {self.address}. Successor is {self.successor}", flush=True)
 
         except requests.exceptions.RequestException as e:
-            # If successor is unresponsive (e.g., crashed), update successor to its next available node
             print(f"Error stabilizing: {e}. Assuming successor {self.successor} is down.", flush=True)
+            self.handle_successor_failure()
 
-            # Here we bypass the crashed node (current successor) and find the next live node
+    def handle_successor_failure(self):
+        """Handle the case when the current successor is unresponsive."""
+        # Try to find the next live node from the successor list
+        for successor in self.successor_list[1:]:  # Skip the current (failed) successor
             try:
-                # Find the next live node in the finger table or get a new successor
-                new_successor = self.find_next_live_successor()
-                if new_successor:
-                    self.successor = new_successor
+                response = requests.get(f"http://{successor}/node-info", timeout=5)
+                response.raise_for_status()
+                self.successor = successor
+                print(f"Updated successor for node {self.address} to {self.successor} after detecting crash.", flush=True)
 
-                    # Notify the new successor that this node is now its predecessor
-                    response = requests.post(f"http://{self.successor}/update-predecessor", json={'predecessor': self.address}, timeout=5)
-                    response.raise_for_status()
+                # Notify the new successor that this node is now its predecessor
+                response = requests.post(f"http://{self.successor}/update-predecessor", json={'predecessor': self.address}, timeout=5)
+                response.raise_for_status()
 
-                    print(f"Updated successor for node {self.address} to {self.successor} after detecting crash.", flush=True)
-                else:
-                    print(f"Failed to find a live successor for node {self.address}.", flush=True)
+                # Update successor list
+                self.update_successor_list()
+                return
+            except requests.exceptions.RequestException:
+                continue  # Try the next successor in the list
 
-            except requests.exceptions.RequestException as e2:
-                print(f"Error contacting next successor: {e2}. The network may be disconnected.", flush=True)
+        print(f"All successors in the list are unresponsive for node {self.address}.", flush=True)
 
-
-    def find_next_live_successor(self):
-        """Attempt to find the next live node in the finger table or using the crashed node's successor."""
+    def update_successor_list(self):
+        """Update the successor list by contacting the current successor."""
         try:
-            # Try contacting the current successor's successor
-            response = requests.get(f"http://{self.successor}/successor", timeout=5)
+            response = requests.get(f"http://{self.successor}/successor-list", timeout=5)
             response.raise_for_status()
-            return response.json()['successor']
-        except requests.exceptions.RequestException:
-            # If contacting the successor's successor fails, try finding the next valid node in the finger table
-            for finger in self.finger_table:
-                try:
-                    response = requests.get(f"http://{finger}/node-info", timeout=5)
-                    response.raise_for_status()
-                    return finger  # Return the first valid node
-                except requests.exceptions.RequestException:
-                    # Skip to the next finger if this node is also unresponsive
-                    continue
-            return None  # Return None if no valid node was found
+            successor_successor_list = response.json()['successor_list']
+            self.successor_list = [self.successor] + successor_successor_list[:-1]
+            print(f"Updated successor list for node {self.address}: {self.successor_list}", flush=True)
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to update successor list for node {self.address}: {e}", flush=True)
+
+    def get_successor_list(self):
+        if self.crashed:
+            return jsonify({'error': 'Node is crashed and cannot get successor list'}), 500
+
+        return jsonify({'successor_list': self.successor_list}), 200
 
 
     def find_successor(self, key_hash, start_node=None):
@@ -346,7 +356,19 @@ def simulate_crash():
 def simulate_recovery():
     node1.crashed = False
     print(f"Node {node1.address} has recovered", flush=True)
-    return jsonify({'message': 'Node has recovered'}), 200
+
+    # Attempt to rejoin the network if the node had previously known a valid successor
+    if node1.successor != node1.address:  # Check if there was a previous known successor
+        try:
+            print(f"Attempting to rejoin the network through previous successor {node1.successor}", flush=True)
+            # Sending a join request to the previous known successor
+            response = requests.post(f"http://{node1.successor}/join", params={'nprime': node1.address})
+            response.raise_for_status()
+            print(f"Rejoined the network successfully through {node1.successor}", flush=True)
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to rejoin the network through {node1.successor}: {e}", flush=True)
+
+    return jsonify({'message': 'Node has recovered and attempted to rejoin the network'}), 200
 
 @app.route('/node-info', methods=['GET'])
 def get_node_info():
@@ -361,8 +383,13 @@ def get_node_info():
         'successor': node1.successor,
         'predecessor': node1.predecessor,
         'finger_table': node1.finger_table,
-        'others': others        
+        'others': others,
+        'successor_list': node1.successor_list    
     }), 200
+
+@app.route('/successor-list', methods=['GET'])
+def get_successor_list():
+    return node1.get_successor_list()
 
 @app.route('/update-predecessor', methods=['POST'])
 def update_predecessor():

--- a/src/network_crash_experiment.py
+++ b/src/network_crash_experiment.py
@@ -3,7 +3,7 @@ import json
 import requests
 import time
 
-TRIALS = 1  # Number of trials for each burst size
+TRIALS = 3
 
 def crash_nodes(nodes, num_crashes):
     """Simulate crashes for a specified number of nodes."""
@@ -20,7 +20,7 @@ def crash_nodes(nodes, num_crashes):
                 print(f"Failed to crash node {node}. Status Code: {response.status_code}")
         except Exception as e:
             print(f"Error crashing node {node}: {str(e)}")
-        time.sleep(1)  # A small delay between crash requests
+        time.sleep(1)  
     return crashed_nodes
 
 def recover_nodes(nodes):
@@ -35,56 +35,47 @@ def recover_nodes(nodes):
                 print(f"Failed to recover node {node}. Status Code: {response.status_code}")
         except Exception as e:
             print(f"Error recovering node {node}: {str(e)}")
-        time.sleep(1)  # A small delay between recovery requests
+        time.sleep(1)  
 
 def is_network_stable(active_nodes, retries=5, delay=20, recheck_delay=5):
     """Check if the network forms a stable ring, with retries to handle delayed updates."""
-    previous_map_length = 0  # Track the length of the successor map from the previous attempt
     for attempt in range(retries):
         visited = set()
         current_node = active_nodes[0]
         successor_map = {}
 
-        # Build a map of each active node's successor
         print(f"\nBuilding successor map (Attempt {attempt + 1}/{retries})...")
-        problematic_nodes = []  # Track nodes with problematic successors
+        problematic_nodes = [] 
         for node in active_nodes:
             try:
                 response = requests.get(f"http://{node}/successor")
                 response.raise_for_status()
                 successor = response.json()['successor']
-                # Only add to the map if the successor is also an active node
                 if successor in active_nodes:
                     successor_map[node] = successor
                 else:
-                    problematic_nodes.append((node, successor))  # Log problematic nodes
+                    problematic_nodes.append((node, successor))  
             except Exception as e:
                 print(f"Error checking successor of {node}: {str(e)}")
                 return False
 
-        # Log the current state of the successor map for debugging
         map_length = len(successor_map)
         print(f"Successor map (length: {map_length}): {successor_map}")
 
-        # Check if all successors are unique
         if len(set(successor_map.values())) == len(active_nodes):
             print("All successors are unique.")
         else:
             print("Some nodes share the same successor.")
             time.sleep(delay)
-            continue  # Retry the check
+            continue 
 
-        # If all active nodes have unique successors and the map length matches the expected number of nodes,
-        # the network should be considered stable.
         if map_length == len(active_nodes):
             print("The network has a complete and unique successor map. Network is stable.")
             return True
 
-        # Wait before the next retry
         print(f"Retrying stability check, attempt {attempt + 1}/{retries}")
         time.sleep(delay)
 
-    # If retries are exhausted, consider the network unstable
     print("Network did not stabilize after all retries.")
     return False
 
@@ -95,32 +86,26 @@ def run_burst_experiments(nodes_list):
     
     while burst_size <= len(nodes_list):
         print(f"\n=== Running experiment for burst size {burst_size} ===\n")
-        
-        # Crash the specified number of nodes
+
         crashed_nodes = crash_nodes(nodes_list, burst_size)
         active_nodes = [node for node in nodes_list if node not in crashed_nodes]
 
-        # Wait for stabilization and check if the network is stable
         print("Checking if the network stabilizes...")
         stable = is_network_stable(active_nodes)
 
         if stable:
             print(f"Network is stable with {burst_size} nodes crashed.")
-            # Recover the crashed nodes
             recover_nodes(crashed_nodes)
 
-            # Add a delay to allow the recovered node(s) to stabilize
             print("Waiting 30 seconds to allow the recovered nodes to stabilize...")
             time.sleep(30)
 
-            # Increase the burst size for the next iteration
             burst_size += 1
         else:
             print(f"Network could not stabilize with {burst_size} nodes crashed.")
             results['max_crash_tolerance'] = burst_size - 1
             break
-    
-    # If we reached the end of the list, record the maximum crash tolerance
+
     if burst_size > len(nodes_list):
         results['max_crash_tolerance'] = len(nodes_list)
     
@@ -132,7 +117,6 @@ def main():
         print("Usage: python network_crash_experiment.py '[\"node1\", \"node2\", ...]'")
         sys.exit(1)
     try:
-        # Parse nodes list
         nodes_list = json.loads(sys.argv[1])
     except json.JSONDecodeError:
         print("Error: The argument should be a valid JSON list of nodes.")
@@ -141,10 +125,8 @@ def main():
         print("Error: You need at least 4 nodes to run the experiment.")
         sys.exit(1)
 
-    # Run the burst experiment
     results = run_burst_experiments(nodes_list)
 
-    # Display results
     print(f"Results: {results}")
 
 if __name__ == "__main__":

--- a/src/network_crash_experiment.py
+++ b/src/network_crash_experiment.py
@@ -1,0 +1,151 @@
+import sys
+import json
+import requests
+import time
+
+TRIALS = 1  # Number of trials for each burst size
+
+def crash_nodes(nodes, num_crashes):
+    """Simulate crashes for a specified number of nodes."""
+    crashed_nodes = []
+    for i in range(num_crashes):
+        node = nodes[i]
+        try:
+            print(f"Crashing node {node}...")
+            response = requests.post(f"http://{node}/sim-crash")
+            if response.status_code == 200:
+                print(f"Node {node} successfully crashed.")
+                crashed_nodes.append(node)
+            else:
+                print(f"Failed to crash node {node}. Status Code: {response.status_code}")
+        except Exception as e:
+            print(f"Error crashing node {node}: {str(e)}")
+        time.sleep(1)  # A small delay between crash requests
+    return crashed_nodes
+
+def recover_nodes(nodes):
+    """Simulate recovery for a list of crashed nodes."""
+    for node in nodes:
+        try:
+            print(f"Recovering node {node}...")
+            response = requests.post(f"http://{node}/sim-recover")
+            if response.status_code == 200:
+                print(f"Node {node} successfully recovered.")
+            else:
+                print(f"Failed to recover node {node}. Status Code: {response.status_code}")
+        except Exception as e:
+            print(f"Error recovering node {node}: {str(e)}")
+        time.sleep(1)  # A small delay between recovery requests
+
+def is_network_stable(active_nodes, retries=5, delay=20, recheck_delay=5):
+    """Check if the network forms a stable ring, with retries to handle delayed updates."""
+    previous_map_length = 0  # Track the length of the successor map from the previous attempt
+    for attempt in range(retries):
+        visited = set()
+        current_node = active_nodes[0]
+        successor_map = {}
+
+        # Build a map of each active node's successor
+        print(f"\nBuilding successor map (Attempt {attempt + 1}/{retries})...")
+        problematic_nodes = []  # Track nodes with problematic successors
+        for node in active_nodes:
+            try:
+                response = requests.get(f"http://{node}/successor")
+                response.raise_for_status()
+                successor = response.json()['successor']
+                # Only add to the map if the successor is also an active node
+                if successor in active_nodes:
+                    successor_map[node] = successor
+                else:
+                    problematic_nodes.append((node, successor))  # Log problematic nodes
+            except Exception as e:
+                print(f"Error checking successor of {node}: {str(e)}")
+                return False
+
+        # Log the current state of the successor map for debugging
+        map_length = len(successor_map)
+        print(f"Successor map (length: {map_length}): {successor_map}")
+
+        # Check if all successors are unique
+        if len(set(successor_map.values())) == len(active_nodes):
+            print("All successors are unique.")
+        else:
+            print("Some nodes share the same successor.")
+            time.sleep(delay)
+            continue  # Retry the check
+
+        # If all active nodes have unique successors and the map length matches the expected number of nodes,
+        # the network should be considered stable.
+        if map_length == len(active_nodes):
+            print("The network has a complete and unique successor map. Network is stable.")
+            return True
+
+        # Wait before the next retry
+        print(f"Retrying stability check, attempt {attempt + 1}/{retries}")
+        time.sleep(delay)
+
+    # If retries are exhausted, consider the network unstable
+    print("Network did not stabilize after all retries.")
+    return False
+
+def run_burst_experiments(nodes_list):
+    """Run experiments with increasing burst sizes of node crashes."""
+    results = {}
+    burst_size = 1
+    
+    while burst_size <= len(nodes_list):
+        print(f"\n=== Running experiment for burst size {burst_size} ===\n")
+        
+        # Crash the specified number of nodes
+        crashed_nodes = crash_nodes(nodes_list, burst_size)
+        active_nodes = [node for node in nodes_list if node not in crashed_nodes]
+
+        # Wait for stabilization and check if the network is stable
+        print("Checking if the network stabilizes...")
+        stable = is_network_stable(active_nodes)
+
+        if stable:
+            print(f"Network is stable with {burst_size} nodes crashed.")
+            # Recover the crashed nodes
+            recover_nodes(crashed_nodes)
+
+            # Add a delay to allow the recovered node(s) to stabilize
+            print("Waiting 30 seconds to allow the recovered nodes to stabilize...")
+            time.sleep(30)
+
+            # Increase the burst size for the next iteration
+            burst_size += 1
+        else:
+            print(f"Network could not stabilize with {burst_size} nodes crashed.")
+            results['max_crash_tolerance'] = burst_size - 1
+            break
+    
+    # If we reached the end of the list, record the maximum crash tolerance
+    if burst_size > len(nodes_list):
+        results['max_crash_tolerance'] = len(nodes_list)
+    
+    print(f"\nMaximum burst size of crashes the network can tolerate: {results['max_crash_tolerance']}")
+    return results
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python network_crash_experiment.py '[\"node1\", \"node2\", ...]'")
+        sys.exit(1)
+    try:
+        # Parse nodes list
+        nodes_list = json.loads(sys.argv[1])
+    except json.JSONDecodeError:
+        print("Error: The argument should be a valid JSON list of nodes.")
+        sys.exit(1)
+    if not isinstance(nodes_list, list) or len(nodes_list) < 4:
+        print("Error: You need at least 4 nodes to run the experiment.")
+        sys.exit(1)
+
+    # Run the burst experiment
+    results = run_burst_experiments(nodes_list)
+
+    # Display results
+    print(f"Results: {results}")
+
+if __name__ == "__main__":
+    main()

--- a/src/run.sh
+++ b/src/run.sh
@@ -6,18 +6,40 @@ if [ -z "$1" ]; then
 fi
 
 NUM_SERVERS=$1
-HOSTS=($(/share/ifi/available-nodes.sh))  # Get all the available nodes
+HOSTS=($(bash /share/ifi/available-nodes.sh))  # Get all the available nodes
 HOST_PORTS=()  # Store host:port combos
 PROJECT_DIR=$PWD
 
+# Create a virtual environment if it does not exist
+VENV_DIR="$PROJECT_DIR/venv"
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating virtual environment..."
+  python3 -m venv $VENV_DIR
+  echo "Virtual environment created at $VENV_DIR"
+fi
+
+# Activate the virtual environment
+source $VENV_DIR/bin/activate
+
+# Install required packages from requirements.txt
+REQUIREMENTS_FILE="$PROJECT_DIR/requirements.txt"
+if [ -f "$REQUIREMENTS_FILE" ]; then
+  echo "Installing required packages..."
+  pip install -r $REQUIREMENTS_FILE
+  echo "Packages installed from $REQUIREMENTS_FILE"
+else
+  echo "requirements.txt not found. Please provide a requirements file for the necessary packages."
+  exit 1
+fi
+
 # Start the servers
-for ((i=0; i<$NUM_SERVERS; i++)); do
+for ((i=0; i<NUM_SERVERS; i++)); do
   HOST=${HOSTS[$i % ${#HOSTS[@]}]}
   PORT=$(shuf -i 49152-65535 -n 1)
 
   HOST_PORT="$HOST:$PORT"
   HOST_PORTS+=("$HOST_PORT")
-  
+
   echo "Starting server on $HOST:$PORT"
   ssh -n -f $HOST "source $PROJECT_DIR/venv/bin/activate && nohup python3 $PROJECT_DIR/Node.py $PORT > $PROJECT_DIR/server_$PORT.log 2>&1 &"
 done
@@ -26,8 +48,8 @@ done
 sleep 5
 
 # Print the nodes list in JSON format
-NODES_LIST=$(printf '"%s",' "${HOST_PORTS[@]}")
-NODES_LIST="[${NODES_LIST%,}]"
+NODES_LIST=$(printf '"%s", ' "${HOST_PORTS[@]}")
+NODES_LIST="[${NODES_LIST%, }]"  # Remove trailing comma
 
 echo "Network nodes in JSON format:"
 echo "$NODES_LIST"

--- a/src/run.sh
+++ b/src/run.sh
@@ -9,12 +9,11 @@ NUM_SERVERS=$1
 HOSTS=($(/share/ifi/available-nodes.sh))  # Get all the available nodes
 HOST_PORTS=()  # Store host:port combos
 PROJECT_DIR=$PWD
-BASE_PORT=8000
 
 # Start the servers
 for ((i=0; i<$NUM_SERVERS; i++)); do
   HOST=${HOSTS[$i % ${#HOSTS[@]}]}
-  PORT=$((BASE_PORT + i))
+  PORT=$(shuf -i 49152-65535 -n 1)
 
   HOST_PORT="$HOST:$PORT"
   HOST_PORTS+=("$HOST_PORT")


### PR DESCRIPTION
POST /sim-crash Simulate a crash. The node must stop processing requests
from other nodes, without notifying them first. Any request or normal
operational messages between nodes should be either completely refused or
responded to with an error code without being acted upon. The "crashed"
node must respond only to the /sim-recover call. Your network must
detect that the node is not responding, and rearrange itself as if the node
has left.

POST /sim-recover Simulate a crash recovery. The node must "recover" from
its simulated crashed state and begin responding again to requests from
other nodes. If the crashed node has been excluded from the network, it
should request to re-join the network via one of its previous neighbors.